### PR TITLE
chat画面のcreated_atの修正

### DIFF
--- a/app/views/layouts/chats_second.html.haml
+++ b/app/views/layouts/chats_second.html.haml
@@ -20,7 +20,7 @@
           - @chats.each do |chat|
             .message
               .message_time
-                = chat.created_at
+                = chat.created_at.to_s(:datetime_jp)
               - if chat.content.present?
                 %p.chats__content
                   = chat.content

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module FirstSkillApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
+    config.time_zone = 'Tokyo'
     config.load_defaults 5.2
     config.autoload_paths += Dir[Rails.root.join('app', 'uploaders')]
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime_jp] = '%Y年 %m月 %d日 %H時 %M分'


### PR DESCRIPTION
## What
時間表記を日本時間に変更
時間の表示を変更

## Why
UIの改善のため