### PR TITLE
basic_authの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
   def after_sign_in_path_for(resource)
     if user_signed_in?
       main_index_path
@@ -19,6 +21,12 @@ class ApplicationController < ActionController::Base
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :language])
+    end
+
+    def basic_auth
+      authenticate_or_request_with_http_basic do |username, password|
+        username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      end
     end
 
 end


### PR DESCRIPTION
## What
ベーシック認証の実装

## Why
デプロイを行なったので不特定の方が入って来ないようにするため。