### PR TITLE
planモデルのバリデーションを設定

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -4,4 +4,9 @@ class Plan < ApplicationRecord
   belongs_to :user
   has_many :plan_skill_tags, dependent: :delete_all
   has_many :skills, through: :plan_skill_tags
+
+  validates :title, presence: true, length: { in: 10..80 }
+  validates :description, presence: true, length: { maximum: 2000 }
+  validates :price, presence: true
+
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
   <%= render "devise/shared/error_messages", resource: resource %>
   <i class="fas fa-file-signature h1 d-block text-center pt-5"></i>
   <div class="field text-center pt-3">
-    <%= f.label "お名前" %><br />
+    <%= f.label "ユーザーネーム" %><br />
     <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "rounded form-control-lg", placeholder: "メンタ太郎" %>
   </div>
   

--- a/app/views/plans/new.html.haml
+++ b/app/views/plans/new.html.haml
@@ -9,7 +9,10 @@
           .mb-5.col-12 プランを登録するとメンターとして掲載されます。
         .row.bg-white 
           .form-group.col-12
-            .h3 タイトル
+            .h4 
+              タイトル
+              %span.text-muted.h6 （10文字以上80文字以下）
+
             .title_description.text-muted 提供できる内容をわかりやすく記載しましょう！
             .title_btn
               = f.text_field :title, placeholder: "初心者サポートします！", class: "form-control"
@@ -29,7 +32,7 @@
           .form-group.col-12 
             .h3 プラン
             .plan_description.text-muted プラン内容は2,000文字以内。
-            = f.text_area :description, placeholder: "プラン内容を記入して下さい", class: "form-control", id: "exampleFormControlTextarea1", rows: "3"
+            = f.text_area :description, placeholder: "プラン内容を記入して下さい", class: "form-control", id: "exampleFormControlTextarea1", rows: "12"
           .form-group.col-4 
             .h3 金額
             = f.text_field :price, placeholder: "10,000", class: "form-control"

--- a/db/migrate/20200226062127_create_plans.rb
+++ b/db/migrate/20200226062127_create_plans.rb
@@ -3,7 +3,7 @@ class CreatePlans < ActiveRecord::Migration[5.2]
     create_table :plans do |t|
       t.string :title, null: false
       t.text :description, null: false
-      t.string :plan_image, null: false
+      t.string :plan_image
       t.integer :price, null: false
       t.references :user, null: false, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_085359) do
   create_table "plans", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
-    t.string "plan_image", null: false
+    t.string "plan_image"
     t.integer "price", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 User.create!(id: 1, name: "test", email: "test@test", password: "11111111", created_at: "2020-01-01", updated_at: "2020-01-10")
-Plan.create!(id: 1, title: "testplan", description: "testdescription", plan_image: "https://cdn.pixabay.com/photo/2017/04/24/11/18/drop-of-water-2256201__480.jpg" , price: 1000, user_id: 1, created_at: "2020-01-01", updated_at: "2020-01-10")
+Plan.create!(id: 1, title: "testplantestplan", description: "testdescription", plan_image: "https://cdn.pixabay.com/photo/2017/04/24/11/18/drop-of-water-2256201__480.jpg" , price: 1000, user_id: 1, created_at: "2020-01-01", updated_at: "2020-01-10")
 Skill.create([{ skill_set: "HTML/CSS"},
               { skill_set: "Ruby"},
               { skill_set: "JavaScript"},


### PR DESCRIPTION
## What
Planモデルにバリデーションを設定（タイトルは空を許容せず、10文字以上80文字以下、プラン内容は2000文字以下、priceは空を許可しない）

## Why
空の投稿や文字数の極端に少ない物は保存させないため。