### PR TITLE
Viewの修正

### DIFF
--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -5,3 +5,12 @@
   color: $main-color;
   @extend .link_style;
 }
+
+.mentor__plan_registration {
+  color: $text-color
+}
+.mentor__plan_registration:hover {
+  color: $text-color;
+  opacity: 0.3;
+  @extend .link_style;
+}

--- a/app/assets/stylesheets/_top.scss
+++ b/app/assets/stylesheets/_top.scss
@@ -5,3 +5,20 @@
   color: $main-color;
   @extend .link_style;
 }
+
+.profile_link {
+  color: $main-color;
+}
+.profile_link:hover {
+  color: $main-color;
+   @extend .link_style;
+}
+
+.plan_title_link {
+  color: $text-color;
+}
+.plan_title_link:hover {
+  color: $text-color;
+  @extend .link_style;
+  opacity: 0.3;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@
 
 .app__title {
   color: $second-color;
+  margin: 0 70px;
 }
 .app__title:hover {
   color: $second-color;

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,6 +1,6 @@
 class TopController < ApplicationController
   def index
-    render "top/index"
+    @plans = Plan.all.last(3)
   end
 
   def mentor_top

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,4 +1,6 @@
 class Plan < ApplicationRecord
+  mount_uploader :plan_image, ImageUploader
+
   has_many :users_plans
   has_many :users, through: :users_plans
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
+  mount_uploader :image_icon, ImageUploader
+  
   has_many :plans
   has_many :users_plans
   # has_many :buy_plans, through: :users_plans, source: :plan

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -10,4 +10,4 @@
       %i.fas.fa-user-cog
       = link_to "設定", edit_user_path(current_user.id), class: "side__menu"
     %li.mt-2
-      = link_to "メンタープランの登録はこちら", new_plan_path, class: "side__menu"
+      = link_to "メンタープランの登録はこちら", new_plan_path, class: "mentor__plan_registration"

--- a/app/views/layouts/_skill_btn.html.haml
+++ b/app/views/layouts/_skill_btn.html.haml
@@ -1,34 +1,42 @@
-.col-12.bg-light.mb-3.d-flex.justify-content-around.text-center.h5{style: "height: 100px;"} 
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.far.fa-file-code.text-info
-      = link_to "HTML/CSS", "#", class: "skill__btn"
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.far.fa-gem.text-info
-      = link_to "Ruby", "#", class: "skill__btn"
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.fab.fa-js.text-info
-      = link_to "JavaScript", "#", class: "skill__btn"
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.fab.fa-python.text-info
-      = link_to "Python", "#", class: "skill__btn"
-.col-12.bg-light.mb-3.d-flex.justify-content-around.text-center.h5{style: "height: 100px;"}
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.fab.fa-php.text-info
-      = link_to "PHP", "#", class: "skill__btn"
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.fab.fa-java.text-info
-      = link_to "Java", "#", class: "skill__btn"
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.fas.fa-database.text-info
-      = link_to "SQL", "#", class: "skill__btn"
-  .col-3.bg-white.mx-1.d-flex.align-items-center
-    .col-12
-      %i.fas.fa-laptop-code.text-info
-      = link_to "その他", "#", class: "skill__btn"
+.row.bg-light.mb-3.d-flex.justify-content-center.text-center.h5
+  .col-md-6.col-lg-3
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"} 
+      .col-12
+        %i.far.fa-file-code.text-info
+        = link_to "HTML/CSS", "#", class: "skill__btn"
+  .col-md-6.col-lg-3  
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"} 
+      .col-12
+        %i.far.fa-gem.text-info
+        = link_to "Ruby", "#", class: "skill__btn"
+  .col-md-6.col-lg-3
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"} 
+      .col-12
+        %i.fab.fa-js.text-info
+        = link_to "JavaScript", "#", class: "skill__btn"
+  .col-md-6.col-lg-3  
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"} 
+      .col-12
+        %i.fab.fa-python.text-info
+        = link_to "Python", "#", class: "skill__btn"
+.row.bg-light.mb-3.d-flex.justify-content-center.text-center.h5
+  .col-md-6.col-lg-3
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"}
+      .col-12
+        %i.fab.fa-php.text-info
+        = link_to "PHP", "#", class: "skill__btn"
+  .col-md-6.col-lg-3  
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"}
+      .col-12
+        %i.fab.fa-java.text-info
+        = link_to "Java", "#", class: "skill__btn"
+  .col-md-6.col-lg-3  
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"}
+      .col-12
+        %i.fas.fa-database.text-info
+        = link_to "SQL", "#", class: "skill__btn"
+  .col-md-6.col-lg-3  
+    .bg-white.mb-1.d-flex.align-items-center.shadow{style: "height: 100px;"}
+      .col-12
+        %i.fas.fa-laptop-code.text-info
+        = link_to "その他", "#", class: "skill__btn"

--- a/app/views/layouts/_skill_btn.html.haml
+++ b/app/views/layouts/_skill_btn.html.haml
@@ -1,0 +1,34 @@
+.col-12.bg-light.mb-3.d-flex.justify-content-around.text-center.h5{style: "height: 100px;"} 
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.far.fa-file-code.text-info
+      = link_to "HTML/CSS", "#", class: "skill__btn"
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.far.fa-gem.text-info
+      = link_to "Ruby", "#", class: "skill__btn"
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.fab.fa-js.text-info
+      = link_to "JavaScript", "#", class: "skill__btn"
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.fab.fa-python.text-info
+      = link_to "Python", "#", class: "skill__btn"
+.col-12.bg-light.mb-3.d-flex.justify-content-around.text-center.h5{style: "height: 100px;"}
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.fab.fa-php.text-info
+      = link_to "PHP", "#", class: "skill__btn"
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.fab.fa-java.text-info
+      = link_to "Java", "#", class: "skill__btn"
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.fas.fa-database.text-info
+      = link_to "SQL", "#", class: "skill__btn"
+  .col-3.bg-white.mx-1.d-flex.align-items-center
+    .col-12
+      %i.fas.fa-laptop-code.text-info
+      = link_to "その他", "#", class: "skill__btn"

--- a/app/views/plans/new.html.haml
+++ b/app/views/plans/new.html.haml
@@ -7,7 +7,7 @@
         .row.mt-5
           .h2.text-info メンタープラン登録
           .mb-5.col-12 プランを登録するとメンターとして掲載されます。
-        .row.bg-white 
+        .row.bg-white.shadow 
           .form-group.col-12.mt-4
             .h4 
               タイトル

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -15,18 +15,25 @@
       .content_image.d-flex
         %image.img-fluid.main_image{src: "https://cdn.pixabay.com/photo/2017/10/28/00/23/mentor-icon-2895941__480.png", alt: "main_image"}
   
-  .main__content.row
+  .main__content.container
+    .main__under_content
+      .h3.text-center.text-info.my-5
+        プログラミング言語から探す 
+      = render "layouts/skill_btn"
+
+  .main__content.container
     .main__under_content
       .h3.text-center.text-info.my-5
         人気のメンターから探す
       .mentor__box.row.mt-5
         // planを配列として取得
         - @plans.each do |plan|
-          .col-4
+          .col-4.bg-white.mx-1
             // plan.userによりplanを持つユーザーをメンターと判定
             = image_tag "#{plan.user.image_icon}", style: "width: 40px; height: 40px; border-radius: 50%;"
             = "#{plan.user.name}"
             %p テストテストテストテストテストテストテストテストテストテストテスト  
+  
         
   .btn__wrapper.row.mt-5
     .user.container

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -13,11 +13,11 @@
 
     .main__view_content.col-lg-6.mb-5
       .content_image.d-flex
-        %image.img-fluid.main_image{src: "https://cdn.pixabay.com/photo/2017/10/28/00/23/mentor-icon-2895941__480.png", alt: "main_image"}
+        = image_tag "https://cdn.pixabay.com/photo/2017/10/28/00/23/mentor-icon-2895941__480.png", class: "img-fluid d-none d-lg-block main_image", alt: ""
   
   .main__content.container
     .main__under_content
-      .h3.text-center.text-info.my-5
+      .h3.text-center.text-info.my-4
         プログラミング言語から探す 
       = render "layouts/skill_btn"
 
@@ -25,32 +25,35 @@
     .main__under_content
       .h3.text-center.text-info.my-5
         新着メンターから探す
-      .mentor__box.row.mt-5
+      .mentor__box.row.mt-5.bg-light.d-flex.justify-content-center
         // planを配列として取得
         - @plans.each do |plan|
-          .col-4.bg-white.mx-1
+          .col-md-3.bg-white.mx-3.my-3.shadow{style: "height: 250px;"}
             // plan.userによりplanを持つユーザーをメンターと判定
-            = image_tag "#{plan.user.image_icon}", style: "width: 40px; height: 40px; border-radius: 50%;"
-            = "#{plan.user.name}"
-            %p テストテストテストテストテストテストテストテストテストテストテスト  
-  
+            = image_tag "#{plan.user.image_icon}", alt: "プロフィール写真", style: "width: 40px; height: 40px; border-radius: 50%; margin: 10px;"
+            = link_to "#{plan.user.name}", "#", class: "profile_link"
+            .col-md-12 
+              = link_to "#{plan.title}", "#", class: "plan_title_link"
+            .col-md-12.position-absolute.fixed-bottom.mb-2
+              = "料金 #{plan.price}円" 
+      .btn.btn-outline-info.btn-lg.mx-auto.my-5.d-block{type: "button", onclick: "location.href='#'", style: "width:400px;"} メンターを探す
         
   .btn__wrapper.row.mt-5
     .user.container
       .user__box.row.mt-5
-        .col-4.text-center
+        .col-md-4.text-center
           %i.fas.fa-globe-asia.text-info.display-4
           .icon_title.text-info オンラインを利用
           %p.mb-5 オンラインによる形式なのでいつでもどこでもプログラミングが学べます。
-        .col-4.text-center
+        .col-md-4.text-center
           %i.fas.fa-chalkboard-teacher.text-info.display-4
           .icon_title.text-info 個別指導
           %p.mb-5 １対１でのやりとりですので個人にあった形式で指導を受けることができます。
-        .col-4.text-center
+        .col-md-4.text-center
           %i.fas.fa-yen-sign.text-info.display-4
           .icon_title.text-info リーズナブル
           %p.mb-5 メンターと直接契約ですのでリーズナブルに指導を受けることができます。
-        .btn.btn-info.btn-lg.mx-auto.mb-5.mt-5.d-block{type: "button", onclick: "location.href='#{new_user_registration_path}'", style: "width:400px;"} ユーザー登録をする
+        .btn.btn-info.btn-lg.mx-auto.my-5.d-block{type: "button", onclick: "location.href='#{new_user_registration_path}'", style: "width:400px;"} ユーザー登録をする
         
 
 

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -14,7 +14,21 @@
     .main__view_content.col-lg-6.mb-5
       .content_image.d-flex
         %image.img-fluid.main_image{src: "https://cdn.pixabay.com/photo/2017/10/28/00/23/mentor-icon-2895941__480.png", alt: "main_image"}
-  .btn__wrapper.row
+  
+  .main__content.row
+    .main__under_content
+      .h3.text-center.text-info.my-5
+        人気のメンターから探す
+      .mentor__box.row.mt-5
+        // planを配列として取得
+        - @plans.each do |plan|
+          .col-4
+            // plan.userによりplanを持つユーザーをメンターと判定
+            = image_tag "#{plan.user.image_icon}", style: "width: 40px; height: 40px; border-radius: 50%;"
+            = "#{plan.user.name}"
+            %p テストテストテストテストテストテストテストテストテストテストテスト  
+        
+  .btn__wrapper.row.mt-5
     .user.container
       .user__box.row.mt-5
         .col-4.text-center
@@ -29,22 +43,7 @@
           %i.fas.fa-yen-sign.text-info.display-4
           .icon_title.text-info リーズナブル
           %p.mb-5 メンターと直接契約ですのでリーズナブルに指導を受けることができます。
-        
-  .main__content.row
-    .main__under_content
-      .review__box.row.mt-5
-        .col-4.text-center
-          = "#{}さんのレビュー"
-          .image_title テスト
-          %p テストテストテストテストテストテストテストテストテストテストテスト  
-        .col-4.text-center
-          = "#{}さんのレビュー"
-          .image_title テスト
-          %p テストテストテストテストテストテストテストテストテストテストテスト  
-        .col-4.text-center
-          = "#{}さんのレビュー"
-          .image_title テスト
-          %p テストテストテストテストテストテストテストテストテストテストテスト  
         .btn.btn-info.btn-lg.mx-auto.mb-5.mt-5.d-block{type: "button", onclick: "location.href='#{new_user_registration_path}'", style: "width:400px;"} ユーザー登録をする
+        
 
 

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -24,7 +24,7 @@
   .main__content.container
     .main__under_content
       .h3.text-center.text-info.my-5
-        人気のメンターから探す
+        新着メンターから探す
       .mentor__box.row.mt-5
         // planを配列として取得
         - @plans.each do |plan|

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -5,7 +5,7 @@
       = form_with model: @user, local: true do |f|
         .row
           .h2.text-info.mb-5 プロフィール
-        .row.bg-white 
+        .row.bg-white.shadow 
           .form-group.col-6.mt-4
             .h3 
               ユーザーネーム

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -5,12 +5,12 @@
     = render 'layouts/sidebar'
     
     .col-9.bg-light
-      .col-12.bg-white.mb-3.d-flex.align-items-center{style: "height: 80px;"} ここには運営からのnewsが表示されます。
-      .col-12.bg-white.mb-3{style: "height: 220px;"} slickで情報を流します。
-      .col-12.bg-white.mb-3{style: "height: 250px;"} 詳細ページ
-      .col-12.bg-white.mb-3{style: "height: 300px;"} plan
+      .col-12.bg-white.mb-3.d-flex.align-items-center.shadow{style: "height: 80px;"} ここには運営からのnewsが表示されます。
+      .col-12.bg-white.mb-3.shadow{style: "height: 220px;"} slickで情報を流します。
+      .col-12.bg-white.mb-3.shadow{style: "height: 250px;"} 詳細ページ
+      .col-12.bg-white.mb-3.shadow{style: "height: 300px;"} plan
       = render "layouts/skill_btn"
-      .col-12.bg-white.mb-3{style: "height: 500px;"} timeline
+      .col-12.bg-white.mb-3.shadow{style: "height: 500px;"} timeline
     .col-12.bg-light{style: "height: 50px;"} 
 
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -9,33 +9,7 @@
       .col-12.bg-white.mb-3{style: "height: 220px;"} slickで情報を流します。
       .col-12.bg-white.mb-3{style: "height: 250px;"} 詳細ページ
       .col-12.bg-white.mb-3{style: "height: 300px;"} plan
-      .col-12.bg-white.mb-3.d-flex.text-center.align-items-center.h5{style: "height: 100px;"} 
-        .col-3
-          %i.far.fa-file-code.text-info
-          = link_to "HTML/CSS", "#", class: "skill__btn"
-        .col-3
-          %i.far.fa-gem.text-info
-          = link_to "Ruby", "#", class: "skill__btn"
-        .col-3
-          %i.fab.fa-js.text-info
-          = link_to "JavaScript", "#", class: "skill__btn"
-        .col-3
-          %i.fab.fa-python.text-info
-          = link_to "Python", "#", class: "skill__btn"
-      .col-12.bg-white.mb-3.d-flex.text-center.align-items-center.h5{style: "height: 100px;"}
-        .col-3
-          %i.fab.fa-php.text-info
-          = link_to "PHP", "#", class: "skill__btn"
-        .col-3
-          %i.fab.fa-java.text-info
-          = link_to "Java", "#", class: "skill__btn"
-        .col-3
-          %i.fas.fa-database.text-info
-          = link_to "SQL", "#", class: "skill__btn"
-        .col-3
-          %i.fas.fa-laptop-code.text-info
-          = link_to "その他", "#", class: "skill__btn"
-        
+      = render "layouts/skill_btn"
       .col-12.bg-white.mb-3{style: "height: 500px;"} timeline
     .col-12.bg-light{style: "height: 50px;"} 
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -6,7 +6,7 @@
     .col-12 
     .col-12.d-flex 
       .col-8.container.bg-white.my-5
-        .row
+        .row.shadow
           .col-12.font-weight-bold
             魅力的なプロフィールを作りましょう！
           .col-12

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,23 @@
-User.create!(id: 1, name: "test", email: "test@test", password: "11111111", created_at: "2020-01-01", updated_at: "2020-01-10")
-Plan.create!(id: 1, title: "testplantestplan", description: "testdescription", plan_image: "https://cdn.pixabay.com/photo/2017/04/24/11/18/drop-of-water-2256201__480.jpg" , price: 1000, user_id: 1, created_at: "2020-01-01", updated_at: "2020-01-10")
+1.upto(10) do |i|
+  User.create(id: "#{i}",
+              email: "test@#{i}",
+              password: "11111111",
+              name: "test#{i}",
+              image_icon: open("#{Rails.root}/public/uploads/user/image_icon/1/0b7e6270924187aed96a8f8c5ae37c63.jpg"),
+              introduce: "テストプレイ#{i}です"
+            )
+end
+
+1.upto(5) do |i|
+  Plan.create(id: "#{i}",
+              title: "テスト#{i}のタイトルです。",
+              description: "プラン#{i}のテストを記入しました",
+              plan_image: open("#{Rails.root}/public/uploads/plan/plan_image/1/ダウンロード.png"),
+              price: "#{i}000",
+              user_id: "#{i}"
+            )
+end
+
 Skill.create([{ skill_set: "HTML/CSS"},
               { skill_set: "Ruby"},
               { skill_set: "JavaScript"},


### PR DESCRIPTION
## What
- top-viewを修正(レスポンシブ化、shadowの追加）
- seedにデータを追記(userとplanを登録）
- top-pageに新着メンターの一覧を表示できるように実装（画像、タイトル、値段）
- skill_btnの部分テンプレート化

## Why
- UI/UXの改善のため
- データ登録の手間を省くため、seedにデータを追記
- 新着メンターを表示してアプリを使用しやすくするため
- DRYに従った設計