### PR TITLE
ユーザー詳細ページにイメージ画像を表示

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,8 @@
-.bg-info.text-white.h2
-  .container.mh-100{style: "height: 100px;"}
-    = "#{@user.name}さん"
+.bg-info.text-white.h3
+  .container.d-flex.py-5
+    = image_tag "#{@user.image_icon}", style: "width: 100px;, height: 100px; border-radius: 50%;"
+    .mx-4{style: "height: 100px;"}
+      = "#{@user.name}"
 .container
   .row
     .col-12 


### PR DESCRIPTION
## What
ユーザー詳細ページにイメージ画像を表示

## Why
プロフィール欄を見やすくするため