### PR TITLE
プラン編集機能の実装

### DIFF
--- a/app/assets/stylesheets/_plans.scss
+++ b/app/assets/stylesheets/_plans.scss
@@ -6,3 +6,11 @@
   text-decoration: none;
   @extend .opacity_style;
 }
+
+.plan__show_link {
+  color: $text-color
+}
+.plan__show_link:hover {
+  color: $main-color;
+  @extend .link_style;
+}

--- a/app/assets/stylesheets/_plans.scss
+++ b/app/assets/stylesheets/_plans.scss
@@ -7,10 +7,10 @@
   @extend .opacity_style;
 }
 
-.plan__show_link {
+.plan__index_link {
   color: $text-color
 }
-.plan__show_link:hover {
+.plan__index_link:hover {
   color: $main-color;
   @extend .link_style;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     if user_signed_in?
-      users_path
+      users_path(id: current_user.id)
     else
       root_path
     end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,5 @@
 class PlansController < ApplicationController
+  before_action :set_plan_params, only: [:show, :edit, :update]
   def new
     @plan = Plan.new
     @plan.skills.build
@@ -15,13 +16,27 @@ class PlansController < ApplicationController
   end
 
   def show
-    @plan = Plan.find(params[:id])
+  end
+
+  def edit
+  end
+
+  def update
+    if @plan.update(plan_params)
+      redirect_to users_path
+    else
+      redierct_back(fallback_location: root_path)
+    end
   end
 
   private
   
   def plan_params
     params.require(:plan).permit(:title, :description, :plan_image, :price, :user_id, skill_ids: [])
+  end
+
+  def set_plan_params
+    @plan = Plan.find(params[:id])
   end
 end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,5 +1,8 @@
 class PlansController < ApplicationController
   before_action :set_plan_params, only: [:show, :edit, :update]
+  def index
+  end
+
   def new
     @plan = Plan.new
     @plan.skills.build
@@ -27,6 +30,9 @@ class PlansController < ApplicationController
     else
       redierct_back(fallback_location: root_path)
     end
+  end
+
+  def noting 
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user_params, only: [:show, :edit, :update]
+  before_action :set_plan_user_id, only: [:index, :show]
   def index
   end
 
@@ -26,4 +27,17 @@ class UsersController < ApplicationController
   def set_user_params
     @user = User.find(params[:id])
   end
+  # @plansでプランを全て取得、その後プランを持つユーザーidを@plan_user_idに格納
+  # @plan_user_idとcurrent_user.idがイコールになれば（current_userがプランを持っていれば）
+  # @plan_user_idを返す
+  def set_plan_user_id
+    @plans = Plan.all
+    @plans.map { |plan|
+    @plan_user_id = plan.user_id
+    if @plan_user_id == current_user.id
+      return @plan_user_id
+    end
+  }
+  end
+
 end

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -7,6 +7,13 @@
       %i.far.fa-address-card
       = link_to "プロフィール", user_path(current_user.id), class: "side__menu"
     %li
+      %i.far.fa-comments
+      // Planを投稿していれば編集へ、投稿していなければ登録を促す画面へ
+      - if Plan.exists?(current_user.id)
+        = link_to "投稿したプラン", edit_plan_path(current_user.id), class: "side__menu"
+      - else
+        = link_to "投稿したプラン", "#", class: "side__menu"
+    %li
       %i.fas.fa-user-cog
       = link_to "設定", edit_user_path(current_user.id), class: "side__menu"
     %li.mt-2

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -8,11 +8,11 @@
       = link_to "プロフィール", user_path(current_user.id), class: "side__menu"
     %li
       %i.far.fa-comments
-      // Planを投稿していれば編集へ、投稿していなければ登録を促す画面へ
-      - if Plan.exists?(current_user.id)
-        = link_to "投稿したプラン", edit_plan_path(current_user.id), class: "side__menu"
+      // Planを投稿していればプラン一覧へ、投稿していなければ投稿を促す画面へ
+      - if @plan_user_id == current_user.id
+        = link_to "投稿したプラン", plans_path(current_user.id), class: "side__menu"
       - else
-        = link_to "投稿したプラン", "#", class: "side__menu"
+        = link_to "投稿したプラン(仮)", noting_plan_path(current_user.id), class: "side__menu"
     %li
       %i.fas.fa-user-cog
       = link_to "設定", edit_user_path(current_user.id), class: "side__menu"

--- a/app/views/plans/_plan_form.html.haml
+++ b/app/views/plans/_plan_form.html.haml
@@ -1,0 +1,34 @@
+.row.bg-white.shadow 
+  .form-group.col-12.mt-4
+    .h4 
+      タイトル
+      %span.text-muted.h6 （10文字以上80文字以下）
+
+    .title_description.text-muted 提供できる内容をわかりやすく記載しましょう！
+    .title_btn
+      = f.text_field :title, placeholder: "初心者サポートします！", class: "form-control"
+  .form-group.col-12 
+    .h3 プラン画像
+    .image_description.text-muted 
+      イメージ画像を掲載しましょう！
+    %label.col-12{for: "plan_plan_image"}
+      .upload__back.bg-light{style: "height: 200px;"}
+        %i.far.fa-image.mx-3.my-3
+          クリックしてイメージ画像を選択
+        = f.file_field :plan_image, class: "d-none"
+  .form-group.col-12
+    .h3 タグ
+    .title_btn
+      = f.collection_check_boxes(:skill_ids, Skill.all, :id, :skill_set, class: "form-control") do |skill|
+        = skill.check_box
+        = skill.text
+      .title_description.text-danger 登録すると検索されやすくなるため成約率が上がります！
+      .title_description.mb-3.text-muted 最大5件まで登録できます 例）Ruby PHP
+  .form-group.col-12 
+    .h3 プラン
+    .plan_description.text-muted プラン内容は2,000文字以内。
+    = f.text_area :description, placeholder: "プラン内容を記入して下さい", class: "form-control", id: "exampleFormControlTextarea1", rows: "12"
+  .form-group.col-4 
+    .h3 金額
+    = f.text_field :price, placeholder: "10,000", class: "form-control"
+    %span.float-right 円／月

--- a/app/views/plans/edit.html.haml
+++ b/app/views/plans/edit.html.haml
@@ -4,10 +4,9 @@
     = render "layouts/sidebar"
     .col-9
       = form_with model: @plan, local: true do |f|
-        .row.mt-5
-          .h2.text-info メンタープラン登録
-          .mb-5.col-12 プランを登録するとメンターとして掲載されます。
+        .row.my-5
+          .h2.text-info メンタープラン編集
         = render partial: "plan_form", locals: { f: f }
         .row.bg-light 
           .form-group.mx-auto.my-5
-            = f.submit "登録する", class: "btn btn-info btn-lg"
+            = f.submit "保存する", class: "btn btn-info btn-lg"

--- a/app/views/plans/index.html.haml
+++ b/app/views/plans/index.html.haml
@@ -1,0 +1,25 @@
+プラン一覧
+.container
+  .row
+    .col-12.bg-light.d-flex.my-5
+      .col-3
+        .col-12.bg-white.shadow.m-2{style: "height: 300px;"}
+          TAG 
+        .col-12.bg-white.shadow.m-2{style: "height: 300px;"} 
+          CATEGORY
+      .col-6
+        .col-12.bg-light.text-info.font-weight-bold.h4.mx-2
+          プラン
+        .col-12.mx-2{style: "height: 50px;"}
+          あなたの教えを待っている人がいます！
+        .col-12.bg-white.shadow.d-flex.align-items-center.mx-2{style: "height: 100px;"}
+          .col-9 
+            プランを登録しましょう
+          .col-3
+            = link_to "登録する", new_plan_path, class: "btn btn-outline-info"
+        .col-12.mt-3
+      .col-3 
+        .col-12.bg-white.shadow.m-2{style: "height: 150px;"}
+          メンター募集
+        .col-12.bg-white.shadow.m-2{style: "height: 150px;"}
+          勉強中

--- a/app/views/plans/noting.html.haml
+++ b/app/views/plans/noting.html.haml
@@ -1,0 +1,25 @@
+.container
+  .row
+    .col-12.bg-light.d-flex.my-5
+      .col-3
+        .col-12.bg-white.shadow.m-2{style: "height: 300px;"}
+          TAG 
+        .col-12.bg-white.shadow.m-2{style: "height: 300px;"} 
+          CATEGORY
+      .col-6
+        .col-12.bg-light.text-info.font-weight-bold.h4.mx-2
+          プラン
+        .col-12.mx-2{style: "height: 50px;"}
+          あなたの教えを待っている人がいます！
+        .col-12.bg-white.shadow.d-flex.align-items-center.mx-2{style: "height: 100px;"}
+          .col-9 
+            プランを登録しましょう
+          .col-3
+            = link_to "登録する", new_plan_path, class: "btn btn-outline-info"
+        .col-12.mt-3
+          プランが見つかりませんでした。
+      .col-3 
+        .col-12.bg-white.shadow.m-2{style: "height: 150px;"}
+          メンター募集
+        .col-12.bg-white.shadow.m-2{style: "height: 150px;"}
+          勉強中

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -5,6 +5,9 @@
         = image_tag "#{@plan.user.image_icon}", class: "mx-auto d-block my-3", style: "width: 150px; height: 150px; border-radius: 50%;"
         .h4.text-center
           = link_to "#{@plan.user.name}", user_path, class: "user__show_link"
+        - if user_signed_in? && current_user.id == @plan.user.id
+          .text-center.mt-5
+            = link_to "プランを編集する", edit_plan_path(@plan.user.id), class: "btn btn-outline-info"
       .col-lg-9.bg-white.shadow.mx-2
         .h2.my-5.pt-3
           = "#{@plan.title}"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -15,10 +15,10 @@
             得意なスキル
           .col-12
             // Planを投稿していれば編集へ、投稿していなければ登録を促す画面へ
-            - if user_signed_in? && Plan.exists?(current_user.id)
-              = link_to "投稿しているプラン", plan_path, class: "plan__show_link"
+            - if user_signed_in? && @plan_user_id == current_user.id
+              = link_to "投稿しているプラン", plans_path, class: "plan__index_link"
             - elsif user_signed_in? && current_user.id == @user.id
-              = link_to "投稿しているプラン", "#", class: "plan__show_link"
+              = link_to "投稿しているプラン", noting_plan_path, class: "plan__index_link"
           - if user_signed_in? && current_user.id == @user.id
             .col-12
               .d-flex.justify-content-end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -13,6 +13,12 @@
             魅力的なプロフィールを作りましょう！
           .col-12
             得意なスキル
+          .col-12
+            // Planを投稿していれば編集へ、投稿していなければ登録を促す画面へ
+            - if user_signed_in? && Plan.exists?(current_user.id)
+              = link_to "投稿しているプラン", plan_path, class: "plan__show_link"
+            - elsif user_signed_in? && current_user.id == @user.id
+              = link_to "投稿しているプラン", "#", class: "plan__show_link"
           - if user_signed_in? && current_user.id == @user.id
             .col-12
               .d-flex.justify-content-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,17 +5,11 @@ Rails.application.routes.draw do
   get 'top', to: 'top#mentor_top'
 
   resources :chats, only: [:index, :create]
-  resources :plans, only: [:new, :create, :show]
+  resources :plans, except: [:index, :destroy]
   resources :users, only: [:index, :show, :edit, :update]
   
 
   namespace :mentors do
     resources :main, only: [:index]
   end
-
-  # devise_scope :user do
-  # get '/users/sign_out' => 'devise/sessions#destroy'
-  
-  # end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   get 'top', to: 'top#mentor_top'
 
   resources :chats, only: [:index, :create]
-  resources :plans, except: [:index, :destroy]
+  resources :plans, except: [:destroy] do
+    member do
+      get 'noting'
+    end
+  end
   resources :users, only: [:index, :show, :edit, :update]
   
 


### PR DESCRIPTION
## What
プラン編集機能を実装
それに伴い、pathの設定（ユーザー詳細画面とサイドバーにプラン編集へのパスを設定）
プランを持っているユーザーとプランを持っていないユーザーで遷移するpathを条件分岐
（プランを持っていればプラン一覧へ。持っていなければプランを登録するように促す）
## Why
プラン編集機能はアプリの根幹機能のため
プランを持っているか持っていないかで表示するviewを変更するために条件分岐を設定した。