### PR TITLE
トップ画面リンクを修正

### DIFF
--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -30,10 +30,10 @@
         - @plans.each do |plan|
           .col-md-3.bg-white.mx-3.my-3.shadow{style: "height: 250px;"}
             // plan.userによりplanを持つユーザーをメンターと判定
-            = image_tag "#{plan.user.image_icon}", alt: "プロフィール写真", style: "width: 40px; height: 40px; border-radius: 50%; margin: 10px;"
-            = link_to "#{plan.user.name}", user_path(plan.user.id), class: "profile_link"
+            = link_to image_tag("#{plan.user.image_icon}", style: "width: 40px; height: 40px; border-radius: 50%; margin: 10px;"), plan_path(plan.id), alt: "プロフィール写真"
+            = link_to "#{plan.user.name}", plan_path(plan.id), class: "profile_link"
             .col-md-12 
-              = link_to "#{plan.title}", plan_path(plan.user.id), class: "plan_title_link"
+              = link_to "#{plan.title}", plan_path(plan.id), class: "plan_title_link"
             .col-md-12.position-absolute.fixed-bottom.mb-2
               = "料金 #{plan.price}円" 
       .btn.btn-outline-info.btn-lg.mx-auto.my-5.d-block{type: "button", onclick: "location.href='#'", style: "width:400px;"} メンターを探す


### PR DESCRIPTION
## What
トップページメンター一覧のリンクをプラン詳細に統一
プランイメージアイコンにリンクを設定

## Why
トップページからはプランをみることが優先されると思われるため