### PR TITLE
users_plansテーブルにplan(new)からuser_idとplan_idを保存するように実装

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -6,7 +6,7 @@ class PlansController < ApplicationController
 
   def new
     @plan = Plan.new
-    @plan.skills.build
+    @plan.users_plans.new
   end
 
   def create
@@ -48,7 +48,7 @@ class PlansController < ApplicationController
   private
   
   def plan_params
-    params.require(:plan).permit(:title, :description, :plan_image, :price, :user_id, skill_ids: [])
+    params.require(:plan).permit(:title, :description, :plan_image, :price, :user_id, users_plans_attributes: [:user_id], skill_ids: [])
   end
 
   def set_plan_params

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,11 +1,13 @@
 class Plan < ApplicationRecord
   mount_uploader :plan_image, ImageUploader
 
-  has_many :users_plans
+  has_many :users_plans, dependent: :delete_all
   has_many :users, through: :users_plans
   belongs_to :user
   has_many :plan_skill_tags, dependent: :delete_all
   has_many :skills, through: :plan_skill_tags
+
+  accepts_nested_attributes_for :users_plans, allow_destroy: true
 
   validates :title, presence: true, length: { in: 10..80 }
   validates :description, presence: true, length: { maximum: 2000 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,8 @@ class User < ApplicationRecord
   mount_uploader :image_icon, ImageUploader
   
   has_many :plans, dependent: :delete_all
+  has_many :plans, through: :users_plans
   has_many :users_plans, dependent: :delete_all
-  # has_many :buy_plans, through: :users_plans, source: :plan
   
   validates :name, presence: true, length: { maximum: 20 }
   validates :introduce, length: { maximum: 500 }

--- a/app/views/plans/_plan_form.html.haml
+++ b/app/views/plans/_plan_form.html.haml
@@ -39,3 +39,5 @@
     .h6.text-muted 1,000円以上1,000,000円以下
     = f.number_field :price, placeholder: "10000", class: "form-control", required: true, min: "1000", max: "1000000"
     %span.float-right 円／月
+    = f.fields_for :users_plans do |i|  
+      = i.hidden_field :user_id, value: current_user.id


### PR DESCRIPTION
## What
- fields_forとaccepts_nested_attributes_forにより、planモデルの子モデルであるusers_plansテーブルに、plan.newから送った値を保存するように実装
- dependent: :delete_allによりplan削除時に紐づくusers_planも削除されるように実装

## Why
プランに紐づくユーザー（メンター）を取得するため