### PR TITLE
tag入力欄をテキストボックスに変更

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -7,6 +7,7 @@ class PlansController < ApplicationController
   def new
     @plan = Plan.new
     @plan.users_plans.new
+    @plan.skills.new
   end
 
   def create
@@ -51,7 +52,7 @@ class PlansController < ApplicationController
   private
   
   def plan_params
-    params.require(:plan).permit(:title, :description, :plan_image, :price, :user_id, users_plans_attributes: [:user_id], skill_ids: [])
+    params.require(:plan).permit(:title, :description, :plan_image, :price, :user_id, users_plans_attributes: [:user_id], skills_attributes: [:skill_set])
   end
 
   def set_plan_params

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -8,9 +8,17 @@ class Plan < ApplicationRecord
   has_many :skills, through: :plan_skill_tags
 
   accepts_nested_attributes_for :users_plans, allow_destroy: true
+  accepts_nested_attributes_for :skills, allow_destroy: true
 
   validates :title, presence: true, length: { in: 10..80 }
   validates :description, presence: true, length: { maximum: 2000 }
   validates :price, presence: true
+
+  before_save :find_or_create_skill
+
+  private
+    def find_or_create_skill
+      self.skills = self.skills.map {|skill| Skill.find_or_create_by(skill_set: skill.skill_set.strip)}
+    end
 
 end

--- a/app/views/plans/_plan_form.html.haml
+++ b/app/views/plans/_plan_form.html.haml
@@ -21,9 +21,10 @@
   .form-group.col-12
     .h3 タグ
     .title_btn
-      = f.collection_check_boxes(:skill_ids, Skill.all, :id, :skill_set, class: "form-control") do |skill|
-        = skill.check_box
-        = skill.label
+      .tags
+        = f.fields_for :skills do |i|
+          = i.label :skill_set, "スキル"
+          = i.text_field :skill_set, id: "formTagInput", class: "form-control"
       .title_description.text-danger 登録すると検索されやすくなるため成約率が上がります！
       .title_description.mb-3.text-muted 最大5件まで登録できます 例）Ruby PHP
   .form-group.col-12 


### PR DESCRIPTION
## What
タグ入力欄をチェックボックスからテキストボックスに変更
同じタグが登録されないようにプランモデルにメソッドを実装

## Why
タグを自由に入力できるようになることで、タグ入力の選択肢が増えUXが向上するため