### PR TITLE
メンター詳細画面へ遷移する際のバグの解消

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -21,7 +21,8 @@
         - if user_signed_in? && current_user.id == @user.id  
           .col-12.my-5.text-center
             = link_to "退会する", delete_confirm_user_path, class: "user__delete_confirm"
-      .col-4 
-        .col-12.my-5.d-flex.justify-content-center
-          = render partial: "relationships/follow_button", locals: { user: @user }
+      .col-4
+        - if user_signed_in? && current_user.id != @user.id
+          .col-12.my-5.d-flex.justify-content-center
+            = render partial: "relationships/follow_button", locals: { user: @user }
     .col-12


### PR DESCRIPTION
## What
#85 トップページからメンター詳細画面へ遷移しようとするとcurrent_user.idがないため、エラーが起こっていた。sign_inしていないとフォローボタンが出現しない仕様にすることでバグを解消した。