### PR TITLE
users_controller単体テスト

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -37,7 +37,7 @@ class PlansController < ApplicationController
 
   def destroy
     if @plan.destroy
-      render "plans/destroy"
+      render :destroy
     else
       redirect_back(fallback_location: root_path)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
 
   def destroy
     if @user.destroy
-      render "users/destroy"
+      render :destroy
     else
       redierct_back(fallback_location: root_path)
     end

--- a/spec/controllers/plans_controller.rb
+++ b/spec/controllers/plans_controller.rb
@@ -90,7 +90,7 @@ describe PlansController do
 	end
 
 	describe 'PATCH #update' do
-		let(:params) { { id: plan.id, plan: attributes_for(:plan, title: "aaaaaaaaaaaaaaa")} }
+		let(:params) { { id: plan.id, plan: attributes_for(:plan, title: "update_test")} }
 		before do
 			login user
 		end
@@ -106,7 +106,7 @@ describe PlansController do
 				}
 				it "レコードが更新されること" do
 					subject
-					expect(plan.reload.title).to eq "aaaaaaaaaaaaaaa"
+					expect(plan.reload.title).to eq "update_test"
 				end
 				it "users_pathにリダイレクトされること" do
 					subject
@@ -120,8 +120,8 @@ describe PlansController do
 					params: invalid_params
 				}
 				it "レコードが更新されないこと" do
-					plan
-					expect{ subject }.not_to change(Plan, :count)
+					subject
+					expect(plan.title).to eq "testタイトルです"
 				end
 				it "editアクションにrenderされること" do
 					subject
@@ -149,9 +149,9 @@ describe PlansController do
 					plan
 					expect{ subject }.to change(Plan, :count).by(-1)
 				end
-				it 'plans/destroyにrenderされること' do
+				it 'destroyのviewがrenderされること' do
 					subject
-					expect(response).to render_template "plans/destroy"
+					expect(response).to render_template :destroy
 				end
 			end
 		end

--- a/spec/controllers/users_controller.rb
+++ b/spec/controllers/users_controller.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+describe UsersController do
+	let(:user) { create(:user) }
+	before do
+		login(user)
+	end
+	describe 'GET #index' do
+		it "@plansに値が配列として入っているか(created_atの降順）" do
+			plans = create_list(:plan, 5)
+			get :index
+			expect(assigns(:plans)).to match(plans.sort{ |a, b| b.created_at <=> a.created_at })
+		end
+		it "indexページが表示されること" do
+			get :index
+			expect(response).to render_template :index
+		end
+	end
+
+	describe 'GET #show' do
+		it "@userに正しい値が入っていること" do
+			get :show, params: { id: user }
+			expect(assigns(:user)).to eq user
+		end
+		it "showページが表示されること" do
+			get :show, params: { id: user }
+			expect(response).to render_template :show
+		end
+	end
+
+	describe 'GET #edit' do
+		it "@userに正しい値が入っていること" do
+			get :edit, params: { id: user }
+			expect(assigns(:user)).to eq user
+		end
+		it "editページが表示されること" do
+			get :edit, params: { id: user }
+			expect(response).to render_template :edit
+		end
+	end
+
+	describe 'PATCH #update' do
+		let(:params) { { id: user.id, user: attributes_for(:user, name: "update_test") } }
+		it "@userに正しい値が入っていること" do
+			patch :update, params: params
+			expect(assigns(:user)).to eq user
+		end
+		context '値の更新に成功した時' do
+			subject {
+				patch :update,
+				params: params
+			}
+			it "レコードが更新されること" do
+				subject
+				expect(user.reload.name).to eq "update_test"
+			end
+			it "users_pathにredirectされること" do
+				subject
+				expect(response).to redirect_to(users_path)
+			end
+		end
+		context '値の更新に失敗した時' do
+			let(:invalid_params) { { id: user.id, user: attributes_for(:user, name: nil) } }
+			subject {
+				patch :update,
+				params: invalid_params
+			}
+			it "レコードが更新されないこと" do
+				subject
+				expect(user.name).to eq "test"
+			end
+			it "editアクションにrenderされること" do
+				subject
+				expect(response).to render_template :edit
+			end
+		end
+	end
+	describe "DELETE #destroy" do
+		subject {
+			delete :destroy,
+			params: { id: user.id }
+		}
+		it "@userの値が正しいこと" do
+			subject
+			expect(assigns(:user)).to eq user
+		end
+		it "レコードが削除されること" do
+			expect{ subject }.to change(User, :count).by(-1)
+		end
+		it "destroyのviewがrenderされること" do
+			subject
+			expect(response).to render_template :destroy
+		end
+	end
+
+	describe "GET #delete_confirm" do
+		it "delete_confirmのviewが表示されること" do
+			get :delete_confirm, params: { id: user }
+			expect(response).to render_template :delete_confirm
+		end
+	end
+end

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     description {"プランのテストを記入しました"}
     plan_image	{"hoge.png"}
     price	      {1000}
+    created_at  { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
     user
   end
 end


### PR DESCRIPTION
## What
#93 
users_controller単体テストの作成
- index
- show
- edit 
- update
- destroy
- delete_confirm
単体テストに伴い、リファクタリングを実行、plans_controller,updateアクションテストの修正