### PR TITLE
プランモデルバリデーション単体テスト #91

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -12,7 +12,7 @@ class Plan < ApplicationRecord
 
   validates :title, presence: true, length: { in: 10..80 }
   validates :description, presence: true, length: { maximum: 2000 }
-  validates :price, presence: true
+  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1000, less_than_or_equal_to: 1000000 }
 
   before_save :find_or_create_skill
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe Plan do
+  describe '#create' do
+    it "is valid with title, description, price" do
+      plan = build(:plan)
+      expect(plan).to be_valid
+    end
+
+    it "is invalid without a title" do
+      plan = build(:plan, title: "") 
+      plan.valid?
+      expect(plan.errors[:title]).to include("を入力してください")
+    end
+
+    it "is invalid with a title that has more than 9 characters" do
+      plan = build(:plan, title: "t" * 9) 
+      plan.valid?
+      expect(plan.errors[:title]).to include("は10文字以上で入力してください")
+    end
+
+    it "is valid with a title that has more than 10 characters" do
+      plan = build(:plan, title: "t" * 10) 
+      expect(plan).to be_valid
+    end
+
+    it "is valid with a title that has less than 80 characters" do
+      plan = build(:plan, title: "t" * 80) 
+      expect(plan).to be_valid
+    end
+
+    it "is invalid with a title that has more than 81 characters" do
+      plan = build(:plan, title: "t" * 81) 
+      plan.valid?
+      expect(plan.errors[:title]).to include("は80文字以内で入力してください")
+    end
+    
+    it "is invalid without a description" do
+      plan = build(:plan, description: "") 
+      plan.valid?
+      expect(plan.errors[:description]).to include("を入力してください")
+    end
+ 
+    it "is invalid with a description that has more than 2001 characters" do
+      plan = build(:plan, description: "t" * 2001)
+      plan.valid?
+      expect(plan.errors[:description]).to include("は2000文字以内で入力してください")
+    end
+    
+    it "is valid with a description that has less than 2000 characters" do
+      plan = build(:plan, description: "t" * 2000)
+      expect(plan).to be_valid
+    end
+
+    it "is invalid without a price" do
+      plan = build(:plan, price: "")
+      plan.valid?
+      expect(plan.errors[:price]).to include("を入力してください")
+    end
+
+    it "is invalid with a price that has less than 999 yen" do
+      plan = build(:plan, price: 999)
+      plan.valid?
+      expect(plan.errors[:price]).to include("は1000以上の値にしてください")
+    end
+
+    it "is valid with a price that has more than 1000 yen" do
+      plan = build(:plan, price: 1000)
+      expect(plan).to be_valid
+    end
+
+    it "is valid with a price that has less than 1000000 yen" do
+      plan = build(:plan, price: 1000000)
+      expect(plan).to be_valid
+    end
+
+    it "is invalid with a price that has more than 1000001 yen" do
+      plan = build(:plan, price: 1000001)
+      plan.valid?
+      expect(plan.errors[:price]).to include("は1000000以下の値にしてください")
+    end
+
+    it "is invalid if not an integer" do
+      plan = build(:plan, price: "test")
+      plan.valid?
+      expect(plan.errors[:price]).to include("は数値で入力してください")
+    end
+    
+  end
+end


### PR DESCRIPTION
## What
プランモデルのバリデーション単体テスト
- タイトルが空で保存できないこと
- タイトルが10文字以上80文字以下であること
- プラン説明が空で保存できないこと
- プランの最大文字数が2000文字以内であること
- 金額が空で保存できないこと
- 金額が1000円以上100万円以下であること
プランモデルに金額のバリデーションを追加
（1000円以上100万円以下）