### PR TITLE
タグ表示バグの修正

### DIFF
--- a/app/assets/stylesheets/_skills.scss
+++ b/app/assets/stylesheets/_skills.scss
@@ -1,6 +1,6 @@
 .tag__link {
   color: $text-color;
-  font-size: 10px;
+  font-size: 14px;
 }
 .tag__link:hover {
   text-decoration: none;

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -2,6 +2,7 @@ class PlansController < ApplicationController
   before_action :set_plan_params, only: [:show, :edit, :update, :destroy]
   def index
     @plans = Plan.all
+    @skills = Skill.first(8)
   end
 
   def new

--- a/app/views/plans/_form.html.haml
+++ b/app/views/plans/_form.html.haml
@@ -21,7 +21,7 @@
   .form-group.col-12
     .h3 タグ
     .title_btn
-      .tags
+      .tags.d-flex
         = f.fields_for :skills do |i|
           = i.label :skill_set, "スキル"
           = i.text_field :skill_set, id: "formTagInput", class: "form-control"

--- a/app/views/plans/_mentor_index.html.haml
+++ b/app/views/plans/_mentor_index.html.haml
@@ -23,9 +23,6 @@
             .col-10
               .col-12.h5.my-3
                 = link_to "#{plan.user.name}", plan_path(plan.id), class: "user__name_link"
-                - plan.skills.each do |skill|
-                  %span.badge.badge-pill.badge-info
-                    = link_to "#{skill.skill_set}", skills_path(id: "#{skill.id}"), class: "tag__link text-white", style: "word-wrap: break-word;"
               .col-12.h5{style: "height: 170px;"}
                 = link_to "#{plan.title}", plan_path(plan.id), class: "plan__show_link pt-3 d-block", style: "word-wrap: break-word;"
               .col-12

--- a/app/views/plans/edit.html.haml
+++ b/app/views/plans/edit.html.haml
@@ -7,7 +7,7 @@
         .row.my-5
           .h2.text-info メンタープラン編集
         = render partial: "shared/errors", locals: { target: @plan }
-        = render partial: "plan_form", locals: { f: f }
+        = render partial: "form", locals: { f: f }
         .row.bg-light 
           .form-group.mx-auto.my-5
             = f.submit "保存する", class: "btn btn-info btn-lg" 

--- a/app/views/plans/index.html.haml
+++ b/app/views/plans/index.html.haml
@@ -5,7 +5,7 @@
         .col-12.bg-white.shadow.m-2{style: "height: 400px; word-wrap: break-word;"}
           TAG
           .col-12
-            - Skill.last(10).each do |skill|
+            - @skills.each do |skill|
               = link_to "# #{skill.skill_set}", skills_path(id: "#{skill.id}"), class: "tag__link m-1 d-block"
         .col-12.bg-white.shadow.m-2{style: "height: 300px;"} 
           CATEGORY

--- a/app/views/plans/new.html.haml
+++ b/app/views/plans/new.html.haml
@@ -8,7 +8,7 @@
           .h2.text-info メンタープラン登録
           .mb-5.col-12 プランを登録するとメンターとして掲載されます。
         = render partial: "shared/errors", locals: { target: @plan }
-        = render partial: "plan_form", locals: { f: f }
+        = render partial: "form", locals: { f: f }
         .row.bg-light 
           .form-group.mx-auto.my-5
             = f.submit "登録する", class: "btn btn-info btn-lg"

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -14,9 +14,10 @@
             = render "messages/new"
       .col-lg-9.bg-white.shadow.mx-2{style: "word-wrap: break-word;"}
         .m-3
-          - @plan.skills.each do |skill|
-            %span.badge.badge-pill.badge-info
-              = link_to "#{skill.skill_set}", skills_path(id: "#{skill.id}"), class: "tag__link text-white"
+          - @plan.plan_skill_tags.each do |tag|
+            - if tag.skill.skill_set != ""
+              %span.badge.badge-pill.badge-info
+                = link_to "#{tag.skill.skill_set}", skills_path(id: "#{tag.skill.id}"), class: "tag__link text-white"
         .h1.my-3.pt-3
           = "#{@plan.title}"
         .h2.my-5.text-center

--- a/app/views/skills/index.html.haml
+++ b/app/views/skills/index.html.haml
@@ -20,9 +20,10 @@
             .col-10
               .col-12.h5.my-3
                 = link_to "#{plan.user.name}", plan_path(plan.id), class: "plan__show_link"
-                - plan.skills.each do |skill|  
-                  %span.badge.badge-pill.badge-info
-                    = link_to "#{skill.skill_set}", skills_path(id: "#{skill.id}"), class: "tag__link text-white", style: "word-wrap: break-word;"
+                - plan.plan_skill_tags.each do |tag|
+                  - if tag.skill.skill_set != ""  
+                    %span.badge.badge-pill.badge-info
+                      = link_to "#{tag.skill.skill_set}", skills_path(id: "#{tag.skill.id}"), class: "tag__link text-white", style: "word-wrap: break-word;"
               .col-12.h5{style: "height: 170px;"}
                 = link_to "#{plan.title}", plan_path(plan.id), class: "plan__show_link"
               .col-12

--- a/spec/controllers/plans_controller.rb
+++ b/spec/controllers/plans_controller.rb
@@ -4,10 +4,15 @@ describe PlansController do
 	let(:user) { create(:user) }
 	let(:plan) { create(:plan) }
 	describe 'GET #index' do
-		it "配列が取得できること" do
+		it "配列が取得できること(@plans)" do
 			plans = create_list(:plan, 3)
 			get :index
 			expect(assigns(:plans)).to match(plans)
+		end
+		it "配列が取得できること(@skills)" do
+			skills = create_list(:skill, 3)
+			get :index
+			expect(assigns(:skills)).to match(skills)
 		end
 		it "indexページが表示されること" do
 			get :index


### PR DESCRIPTION
## What
#103 
タグ表示バグの修正
タグがない場合に表示されないように条件分岐
タグ一覧画面に８件のみ表示するよう修正
plans_controller単体テスト、indexアクションのインスタンス変数（@skills）の記述を作成
## Why
バグの修正のため