### PR TITLE
プラン統合テスト

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,10 +3,6 @@ class MessagesController < ApplicationController
   def index
     @messages = Message.where(user_id: current_user.id).order("created_at DESC")
   end
-  
-  def new
-    @message = Message.new
-  end
 
   def create
     @message = Message.new(message_params)

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,7 +16,7 @@
         </div>
 
         <div class="actions text-center mt-4">
-          <%= f.submit "ログイン", class: "col-6 col-md-3 btn btn-info btn-lg rounded" %>
+          <%= f.submit "ログイン", class: "login__main_btn col-6 col-md-3 btn btn-info btn-lg rounded" %>
         </div>
 
         <% if devise_mapping.rememberable? %>

--- a/app/views/plans/_form.html.haml
+++ b/app/views/plans/_form.html.haml
@@ -21,10 +21,10 @@
   .form-group.col-12
     .h3 タグ
     .title_btn
-      .tags.d-flex
+      .tags
         = f.fields_for :skills do |i|
           = i.label :skill_set, "スキル"
-          = i.text_field :skill_set, id: "formTagInput"
+          = i.text_field :skill_set, id: "formTagInput", class: "form-control"
       .title_description.text-danger 登録すると検索されやすくなるため成約率が上がります！
       .title_description.mb-3.text-muted 最大5件まで登録できます 例）Ruby PHP
   .form-group.col-12 

--- a/app/views/plans/index.html.haml
+++ b/app/views/plans/index.html.haml
@@ -26,7 +26,7 @@
                 .py-3.text-center
                   = link_to image_tag("#{plan.plan_image}", onerror: "this.src='https://www.silhouette-illust.com/wp-content/uploads/2017/01/book_pen_23791-300x300.jpg'"), plan_path(plan.id), class: "plan__show_link"
                 .pb-5
-                  = link_to "#{plan.title}", plan_path(plan.id), class: "plan__show_link", style: "word-wrap: break-word"
+                  = link_to "#{plan.title}", plan_path(plan.id), class: "plan__show_link plan__show_link_title", style: "word-wrap: break-word"
         .col-12.mt-3
       .col-3 
         .col-12.bg-white.shadow.m-2{style: "height: 150px;"}

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -26,17 +26,15 @@
       .h3.text-center.text-info.my-5
         新着メンターから探す
       .mentor__box.row.mt-5.bg-light.d-flex.justify-content-center
-        // planを配列として取得
         - @plans.each do |plan|
           .col-lg-3.bg-white.mx-3.my-3.shadow{style: "height: 250px;"}
-            // plan.userによりplanを持つユーザーをメンターと判定
             = link_to image_tag("#{plan.user.image_icon}", style: "width: 40px; height: 40px; border-radius: 50%; margin: 10px;", onerror: "this.src='https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRQfY6o0sCSzzGmKM5M23o8EJVUSeu1sq1bJcddtlZDGPip9A36'"), plan_path(plan.id), alt: "プロフィール写真"
             = link_to "#{plan.user.name}", plan_path(plan.id), class: "user__name_link"
             .col-12 
               = link_to "#{plan.title}", plan_path(plan.id), class: "plan_title_link", style: "word-wrap: break-word;"
             .col-12.position-absolute.fixed-bottom.mb-2
               = "料金 #{plan.price}円" 
-      .btn.btn-outline-info.btn-lg.mx-auto.my-5.d-block{type: "button", onclick: "location.href='#{all_mentor_plans_path}'", style: "width:400px;"} メンターを探す
+      = link_to "メンターを探す", all_mentor_plans_path, class: "find_mentors_btn btn btn-outline-info btn-lg mx-auto my-5 d-block", style: "width:400px;"
         
   .btn__wrapper.row.mt-5
     .user.container

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -15,23 +15,25 @@
           %li
             =image_tag "https://cdn.pixabay.com/photo/2014/08/10/08/05/speakers-414560__480.jpg", style: "height: 220px; width: 100%;"
       .col-12.bg-white.mb-3.shadow{style: "height: 250px;"} 詳細ページ
-      .py-3{style: "height: 600px;"}
+      .py-3
         メンター
-        .my-3.d-flex{style: "height: 220px;"}
+      - if @plans[0..2] != nil
+        .my-3.d-flex
           - @plans[0..2].each do |plan|
-            .col-4.bg-white.mx-1.shadow
+            .col-4.bg-white.mx-1.shadow{style: "height: 220px;"}
               .d-flex.align-items-center
                 = link_to image_tag("#{plan.user.image_icon}", onerror: "this.src='https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRQfY6o0sCSzzGmKM5M23o8EJVUSeu1sq1bJcddtlZDGPip9A36'", style: "width: 40px; height: 40px; border-radius: 50%;"), plan_path(plan.id), style: "width: 75px; height: 75px; border-radius: 50%;", class: "mt-3"
                 = link_to "#{plan.user.name}", plan_path(plan.id), class: "user__name_link"
               = link_to "#{plan.title}", plan_path(plan.id), class: "plan__show_link", style: "word-wrap: break-word;"
-        .my-3.d-flex{style: "height: 220px;"}
+      - if @plans[3..5] != nil
+        .my-3.d-flex
           - @plans[3..5].each do |plan|
-            .col-4.bg-white.mx-1.shadow
+            .col-4.bg-white.mx-1.shadow{style: "height: 220px;"}
               .d-flex.align-items-center
                 = link_to image_tag("#{plan.user.image_icon}", onerror: "this.src='https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRQfY6o0sCSzzGmKM5M23o8EJVUSeu1sq1bJcddtlZDGPip9A36'", style: "width: 40px; height: 40px; border-radius: 50%;"), plan_path(plan.id), style: "width: 75px; height: 75px; border-radius: 50%;", class: "mt-3"
                 = link_to "#{plan.user.name}", plan_path(plan.id), class: "user__name_link"
               = link_to "#{plan.title}", plan_path(plan.id), class: "plan__show_link", style: "word-wrap: break-word;"
-        .text-muted
+        .text-muted.my-4
           = link_to "もっとみる", all_mentor_plans_path, class: "mentor__link"
       = render "shared/skill_btn"
       .col-12.bg-white.mb-3.shadow{style: "height: 500px;"} timeline

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   end
 
   resources :users, except: [:new, :create] do
-    resources :messages, only: [:index, :new, :create, :show]
+    resources :messages, only: [:index, :create, :show]
     member do 
       get "delete_confirm"
     end

--- a/spec/controllers/plans_controller.rb
+++ b/spec/controllers/plans_controller.rb
@@ -161,4 +161,16 @@ describe PlansController do
 			end
 		end
 	end
+
+	describe 'GET #new_arrival_mentor' do
+		it "配列が新着順に取得できること" do
+			plans = create_list(:plan, 5)
+			get :new_arrival_mentor
+			expect(assigns(:plans)).to match(plans.sort{ |a, b| b.created_at <=> a.created_at })
+		end
+		it "新着メンター画面が表示されること" do
+			get :new_arrival_mentor
+			expect(response).to render_template :new_arrival_mentor
+		end
+	end
 end

--- a/spec/features/plan_spec.rb
+++ b/spec/features/plan_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 feature 'plan', type: :feature do
 	given(:user) { create(:user) }
 	given(:plan) { create(:plan) }
+	given(:plans) { create_list(:plan, 5) }
   scenario 'ログインからプラン投稿、編集、削除まで' do
 		visit root_path
 		expect(page).to have_content('First Skill App')
@@ -55,9 +56,10 @@ feature 'plan', type: :feature do
 		click_link('プランを編集する')
 		click_on('削除する')
 		expect(page).to have_content('プランを削除しました')
-  end
+	end
+	
 	feature 'プラン一覧の確認' do
-		scenario 'プランがない時はプランが表示されない' do
+		scenario 'プランがない時はプランが表示されないこと' do
 			visit new_user_session_path
 			fill_in 'user_email', with: user.email
 			fill_in 'user_password', with: user.password
@@ -66,6 +68,38 @@ feature 'plan', type: :feature do
 			expect(current_path).to eq plans_path
 			expect(page).to have_no_link(".plan__show_link")
 			expect(page).to have_no_selector(".plan__show_link")
+		end
+	end
+
+	feature '検索機能' do
+		context 'プランが見つかった時' do
+			scenario '検索ワードに紐づくメンターが表示されること' do
+				plan
+				visit root_path
+				fill_in 'keyword', with: "test"
+				click_on('検索')
+				expect(page).to have_link('testタイトルです')
+			end
+		end
+		context 'プランが見つからなかった時' do
+			scenario '見つかりませんでしたと表示されること' do
+				visit root_path
+				fill_in 'keyword', with: "失敗"
+				click_on('検索')
+				expect(page).to have_content('見つかりませんでした。')
+			end
+		end
+	end
+	feature 'メンター表示機能' do
+		scenario '総合と新着メンターが表示されること' do
+			plans
+			visit root_path
+			click_link('メンターを探す')
+			expect(current_path).to eq all_mentor_plans_path
+			expect(page).to have_link('test')
+			click_link('新着')
+			plans.reverse
+			expect(current_path).to eq new_arrival_mentor_plans_path
 		end
 	end
 end

--- a/spec/features/plan_spec.rb
+++ b/spec/features/plan_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 feature 'plan', type: :feature do
 	given(:user) { create(:user) }
-  scenario 'ログインからプラン投稿まで' do
+	given(:plan) { create(:plan) }
+  scenario 'ログインからプラン投稿、編集、削除まで' do
 		visit root_path
 		expect(page).to have_content('First Skill App')
 		expect(page).to have_content('ログイン')
@@ -24,12 +25,47 @@ feature 'plan', type: :feature do
 			click_link('メンタープランの登録はこちら')
 			expect(current_path).to eq new_plan_path
 			fill_in 'plan_title', with: 'テストタイトルです。'
+			fill_in 'formTagInput', with: 'HTML'
 			fill_in 'plan_description', with: 'テストです。'
       fill_in 'plan_price', with: 1000
       click_on '登録する'
     }.to change(Plan, :count).by(1)
     expect(current_path).to eq users_path
-    expect(page).to have_selector('.user__name_link')
+		expect(page).to have_selector('.user__name_link')
+		# プラン一覧確認
+		click_link('投稿したプラン')
+		expect(current_path).to eq plans_path
+		find(".plan__show_link_title").click
+		expect(current_path).to eq plan_path("#{plan.id - 1}")
+		# プラン編集
+		click_link('プランを編集する')
+		expect(current_path).to eq edit_plan_path("#{plan.id - 1}")
+		fill_in 'plan_title', with: 'プランタイトルを編集しました'
+		fill_in 'formTagInput', with: 'Ruby'
+		fill_in 'plan_description', with: 'プラン説明を編集しました'
+		fill_in 'plan_price', with: 10000
+		click_on('保存する')
+		expect(page).to have_content('プランタイトルを編集しました')
+		click_on('プランタイトルを編集しました')
+		expect(page).to have_content('プランタイトルを編集しました')
+		expect(page).to have_link('Ruby')
+		expect(page).to have_content('プラン説明を編集しました')
+		expect(page).to have_content(10000)
+		# プラン削除
+		click_link('プランを編集する')
+		click_on('削除する')
+		expect(page).to have_content('プランを削除しました')
   end
-
+	feature 'プラン一覧の確認' do
+		scenario 'プランがない時はプランが表示されない' do
+			visit new_user_session_path
+			fill_in 'user_email', with: user.email
+			fill_in 'user_password', with: user.password
+			find(".login__main_btn").click
+			click_link('投稿したプラン')
+			expect(current_path).to eq plans_path
+			expect(page).to have_no_link(".plan__show_link")
+			expect(page).to have_no_selector(".plan__show_link")
+		end
+	end
 end

--- a/spec/features/plan_spec.rb
+++ b/spec/features/plan_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+feature 'plan', type: :feature do
+	given(:user) { create(:user) }
+  scenario 'ログインからプラン投稿まで' do
+		visit root_path
+		expect(page).to have_content('First Skill App')
+		expect(page).to have_content('ログイン')
+		expect(page).to have_content('無料登録')
+		expect(page).to have_no_content('ログアウト')
+		expect(page).to have_no_content('HOME')
+		# ログイン処理
+		visit new_user_session_path
+		fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: user.password
+    find(".login__main_btn").click
+		expect(current_path).to eq users_path
+		expect(page).to have_no_content('First Skill App')
+		expect(page).to have_no_content('ログイン')
+		expect(page).to have_no_content('無料登録')
+		expect(page).to have_content('HOME')
+		expect(page).to have_content('ログアウト')
+		# プラン作成
+		expect {
+			click_link('メンタープランの登録はこちら')
+			expect(current_path).to eq new_plan_path
+			fill_in 'plan_title', with: 'テストタイトルです。'
+			fill_in 'plan_description', with: 'テストです。'
+      fill_in 'plan_price', with: 1000
+      click_on '登録する'
+    }.to change(Plan, :count).by(1)
+    expect(current_path).to eq users_path
+    expect(page).to have_selector('.user__name_link')
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
## What
#97 
- capybaraの導入
プラン統合テストの作成
- ログインからプラン投稿ができること
- プラン詳細が見られること
- プラン編集ができること
- プラン削除ができること
- メンター一覧（総合、新着が確認できること）
- プランがない時はプランが表示されないこと
- タイトルで検索できること
- 検索した内容が見つからなければ見つかりませんでしたと表示されること

- plans_controller単体テストの追加(新着メンターが新着順に取得できること)

- 不要な記述を削除(plans_controller,newアクション)
- プランがない時にエラーが起こらないように条件分岐を設定