### PR TITLE
プラン詳細クリック時の条件分岐統合テスト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
 	gem 'faker', "~> 2.8"
+  gem 'launchy'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
       kaminari-core (= 1.2.0)
     kaminari-core (1.2.0)
     kgio (2.11.3)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -337,6 +339,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   kaminari
+  launchy
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/spec/features/plan_spec.rb
+++ b/spec/features/plan_spec.rb
@@ -71,6 +71,47 @@ feature 'plan', type: :feature do
 		end
 	end
 
+	feature '自分のプランを選択した時' do
+		given(:own_plan) { create(:plan, user_id: user.id) }
+		given(:others_plan) { Plan.create(id: plan.id, user_id: user.id + 1) }
+		context '自分のプランを選択した場合' do
+			background {
+				own_plan
+				visit new_user_session_path
+				fill_in 'user_email', with: user.email
+				fill_in 'user_password', with: user.password
+				find(".login__main_btn").click
+			}
+			scenario 'メッセージで相談、フォローボタンが表示されないこと' do
+				click_link('testタイトルです')
+				expect(page).to have_no_button('メッセージで相談')
+				expect(page).to have_no_button('フォローする')
+			end
+			scenario 'プランを編集するボタンが表示されること' do
+				click_link('testタイトルです')
+				expect(page).to have_link('プランを編集する')
+			end
+		end
+		context '他人のプランを選択した場合' do
+			background {
+				others_plan
+				visit new_user_session_path
+				fill_in 'user_email', with: user.email
+				fill_in 'user_password', with: user.password
+				find(".login__main_btn").click
+			}
+			scenario 'メッセージで相談、フォローボタンが表示されること' do
+				click_link('testタイトルです')
+				expect(page).to have_button('メッセージで相談')
+				expect(page).to have_button('フォローする')
+			end
+			scenario 'プランを編集するボタンが表示されないこと' do
+				click_link('testタイトルです')
+				expect(page).to have_no_link('プランを編集する')
+			end
+		end
+  end
+
 	feature '検索機能' do
 		context 'プランが見つかった時' do
 			scenario '検索ワードに紐づくメンターが表示されること' do


### PR DESCRIPTION
## What
#97 
プラン詳細をクリックした時に表示されるボタンやリンクに関する統合テストを作成
- 自分のプランであればフォローボタン、メッセージで相談ボタンが表示されないこと
- 自分のプランであればプランを編集するボタンが表示されること
- 他人のプランであればフォローボタン、メッセージで相談ボタンが表示されること
- 他人のプランであればプランを編集するボタンが表示されないこと
- テスト環境でデバッグを行やすくするためgem launchyをインストール
## Why
条件分岐によって表示させるボタンを変えることでユーザーに機能の制限をかけられ、使いやすいアプリになる（プラン編集は他人が行えない等）
それらの機能を確かめるため、統合テストを作成