### PR TITLE
ユーザー各種機能統合テスト

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,13 @@ class User < ApplicationRecord
   has_many :users_plans, dependent: :delete_all
   has_many :plans, through: :users_plans
   has_many :plans, dependent: :delete_all
-  has_many :relationships
+  has_many :relationships, dependent: :delete_all
   has_many :followings, through: :relationships, source: :follow
-  has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id'
+  has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id', dependent: :delete_all
   has_many :followers, through: :reverse_of_relationships, source: :user
   has_many :messages, dependent: :delete_all
-
+  has_many :replymessages, class_name: 'Message', foreign_key: 'sender_id', dependent: :delete_all
+  
   validates :name, presence: true, length: { maximum: 20 }
   validates :introduce, length: { maximum: 500 }
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,6 @@
 .bg-info.text-white.h3
   .container.d-flex.py-5
-    = image_tag "#{@user.image_icon}", style: "width: 100px;, height: 100px; border-radius: 50%;", onerror: "this.src='https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRQfY6o0sCSzzGmKM5M23o8EJVUSeu1sq1bJcddtlZDGPip9A36'"
+    = image_tag "#{@user.image_icon}", style: "width: 100px; height: 100px; border-radius: 50%;", onerror: "this.src='https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRQfY6o0sCSzzGmKM5M23o8EJVUSeu1sq1bJcddtlZDGPip9A36'"
     .mx-4{style: "height: 100px;"}
       = "#{@user.name}"
 .container

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+feature 'user', type: :feature do
+  given(:user) { create(:user) }
+  feature 'メインページでプロフィールリンクを押した時' do
+    background {
+      visit new_user_session_path
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+      find(".login__main_btn").click
+    }
+    scenario 'user_pathに遷移し各リンクが表示されること' do
+      click_on('プロフィール')
+      expect(current_path).to eq user_path(user)
+      expect(page).to have_selector 'img'
+      expect(page).to have_link('投稿しているプラン')
+      expect(page).to have_link('プロフィールを編集する')
+      expect(page).to have_link('退会する')
+    end
+  end
+
+  feature '投稿しているプランを押した時' do
+    background {
+      visit new_user_session_path
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+      find(".login__main_btn").click
+      click_on('プロフィール')
+    }
+    scenario 'プラン一覧画面に遷移すること' do
+      click_on('投稿しているプラン')
+      expect(current_path).to eq plans_path
+    end
+  end
+
+  feature 'プロフィールを編集するを押した時' do
+    background {
+      visit new_user_session_path
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+      find(".login__main_btn").click
+      click_on('プロフィール')
+      click_on('プロフィールを編集する')
+    }
+    scenario 'プロフィール編集画面に遷移すること' do
+      expect(current_path).to eq edit_user_path(user)
+    end
+    scenario 'プロフィールが編集できること' do
+      fill_in 'user_name', with: "ユーザーネームを編集しました"
+      attach_file 'user_image_icon', "#{Rails.root}/public/uploads/user/image_icon/1/ダウンロード.png"
+      fill_in 'user_introduce', with: "自己紹介を編集しました"
+      click_on('保存する')
+      expect(current_path).to eq users_path
+      click_on('プロフィール')
+      expect(page).to have_content('ユーザーネームを編集しました')
+    end
+  end
+
+  feature '退会するを押した時' do
+    background {
+      visit new_user_session_path
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+      find(".login__main_btn").click
+      click_on('プロフィール')
+      click_on('退会する')
+    }
+    scenario '退会確認画面に遷移すること' do
+      expect(current_path).to eq delete_confirm_user_path(user)
+    end
+    scenario '退会確認画面からプラン作成画面に遷移できること' do
+      click_on('プランを登録')
+      expect(current_path).to eq new_plan_path
+    end
+    scenario '退会確認画面からメンター一覧画面に遷移できること' do
+      click_on('メンターを探す')
+      expect(current_path).to eq all_mentor_plans_path
+    end
+    scenario '退会(ユーザー削除)ができること' do
+      click_button('退会する')
+      expect(page).to have_content('退会するボタンを押すと全てのデータが削除されます')
+      click_link('退会する')
+      expect(page).to have_content('データの削除が完了しました')
+      click_on('トップへ戻る')
+      expect(current_path).to eq root_path
+    end
+  end
+  feature '設定を押した時' do
+    background {
+      visit new_user_session_path
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+      find(".login__main_btn").click
+      click_on('設定')
+    }
+    scenario 'ユーザー編集画面に遷移すること' do
+      expect(current_path).to eq edit_user_path(user)
+    end
+    scenario 'ユーザー編集画面に値が保持されていること' do
+      expect(page).to have_content('test')
+    end
+  end
+end
+
+


### PR DESCRIPTION
## What
#97 
ユーザー機能の統合テスト
- メインページからプロフィールリンクを押した時ユーザー詳細ページが表示されることを確認
- 詳細ページには、投稿しているプラン・プロフィールを編集する・退会するリンクが表示されていることを確認
- 投稿しているプランを押すと投稿しているプラン一覧が表示されることを確認
- プロフィールを編集するを押すとプロフィール編集画面に遷移し、プロフィールを更新できることを確認
- 退会するを押すと退会確認ページに遷移することを確認
- 退会確認ページからプランを登録するページへ遷移することを確認
- 退会確認ページからメンター一覧ページに遷移することを確認
- 退会確認ページから退会ができることを確認
- ユーザーがメッセージを持っている場合とフォロワーを持っている場合に削除できなかったためdependent: :delete_allを設定しユーザー削除時に共に削除ができるように実装した