### PR TITLE
circleci/configの修正とmysqlpasswordの変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,3 +80,15 @@ jobs:
       - run:
           name: run rubocop
           command: bundle exec rubocop
+
+      - add_ssh_keys:
+          fingerprints:
+            - "9e:a2:9f:fa:37:04:e7:d5:97:3a:a7:2f:c7:f7:db:d1"
+
+      - deploy:
+          name: Capistrano deploy
+          command: |
+            if [ "${CIRCLE_BRANCH}" != "master" ]; then
+              exit 0
+            fi
+            bundle exec cap production deploy

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 public/uploads/*
+.env
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,20 +17,19 @@ default: &default
   username: root
   password: password0000
   socket: /tmp/mysql.sock
-  host: db
-  
+
 
 development:
   <<: *default
   database: first_skill_app_development
-
+  host: db
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
   database: first_skill_app_test
-
+  host: db
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.
@@ -56,3 +55,4 @@ production:
   username: root
   password: <%= ENV['DATABASE_PASSWORD'] %>
   socket: /var/lib/mysql/mysql.sock
+  host: <%= ENV['DATABASE_HOST'] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
     environment:
       MYSQL_DATABASE: first_skill_app_development
-      MYSQL_ROOT_PASSWORD: password0000
+      MYSQL_ROOT_PASSWORD: ${ROOTPASS}
     # volumes:
     #   - ./mysql/mysql_data:/var/lib/mysql 
     ports:


### PR DESCRIPTION
## What
- .circleci/config.ymlにCircleCIとCapistranoを連携する記述を作成
  - 自動デプロイをマージ後に行うため
- mysqlのパスワードを変更
  - セキュリティのため